### PR TITLE
Eq 146 and Eq 150 and Supporting Lemma

### DIFF
--- a/src/matrix_cookbook/3_inverses.lean
+++ b/src/matrix_cookbook/3_inverses.lean
@@ -37,14 +37,15 @@ begin
 
   rw adjugate, 
   dsimp,
-  rw cramer_transpose_apply,
-  rw det_succ_row _ i,
-  conv_lhs { apply_congr, skip, rw update_row_apply, },
+  rw [cramer_transpose_apply, det_succ_row _ i],
+  conv_lhs 
+  { apply_congr, skip, rw update_row_apply, },
   simp only [eq_self_iff_true, if_true],
-  conv_lhs {apply_congr, skip, rw pi.single_apply j (1:ℂ) x, 
-  rw mul_ite, rw ite_mul, rw mul_zero, rw zero_mul, },
-  simp only [mul_one, finset.sum_ite_eq', finset.mem_univ, if_true, 
-    neg_one_pow_mul_eq_zero_iff],
+  conv_lhs 
+  {apply_congr, skip, rw pi.single_apply j (1:ℂ) x, 
+    rw [mul_ite, ite_mul, mul_zero, zero_mul], },
+  simp only [mul_one, finset.sum_ite_eq', 
+    finset.mem_univ, if_true, neg_one_pow_mul_eq_zero_iff],
   rw submatrix_update_row_succ_above,
 end
 lemma eq_147 : (adjugate A)ᵀ = of (λ i j, adjugate A j i) := rfl

--- a/src/matrix_cookbook/3_inverses.lean
+++ b/src/matrix_cookbook/3_inverses.lean
@@ -21,12 +21,19 @@ lemma eq_145 (h : is_unit A.det) : A * A⁻¹ = 1 ∧ A⁻¹ * A = 1 :=
 ⟨mul_nonsing_inv _ h, nonsing_inv_mul _ h⟩
 
 /-! ### Cofactors and Adjoint -/
+def cofactor {n : ℕ} (A : matrix (fin n.succ) (fin n.succ) ℂ) := 
+  matrix.of (λ i j: (fin n.succ), (-1)^(i + j : ℕ) * det (A.submatrix i.succ_above j.succ_above))
 
-lemma eq_146 (n : ℕ) (A : matrix (fin n.succ) (fin n.succ) ℂ) (i j) :
-  adjugate A j i = (-1)^(i + j : ℕ) * det (A.submatrix i.succ_above j.succ_above) := 
-adjugate_eq_det_submatrix A j i
-lemma eq_147 : (adjugate A)ᵀ = of (λ i j, adjugate A j i) := rfl
-lemma eq_148 : adjugate A = (adjugate A)ᵀᵀ := rfl
+lemma eq_146 {n : ℕ} (A : matrix (fin n.succ) (fin n.succ) ℂ) (i j) :
+  cofactor A i j = (-1)^(i + j : ℕ) * det (A.submatrix i.succ_above j.succ_above) := 
+by rw [cofactor, of_apply]
+
+lemma eq_147 {n : ℕ} (A : matrix (fin n.succ) (fin n.succ) ℂ) : 
+  (cofactor A) = of (λ i j, cofactor A i j) := rfl -- eq_147 is a trivial matrix definiton!
+
+lemma eq_148 {n : ℕ} (A : matrix (fin n.succ) (fin n.succ) ℂ) : adjugate A = (cofactor A)ᵀ := begin
+  funext r s, rw [transpose_apply, cofactor, adjugate_eq_det_submatrix], refl,
+end
 
 /-! ### Determinant -/
 

--- a/src/matrix_cookbook/3_inverses.lean
+++ b/src/matrix_cookbook/3_inverses.lean
@@ -30,7 +30,8 @@ begin
   is to show equivalence of that definiton to the cofactor definition. Eric mentions that
   mathlib people do not prefer new definitions so we will not use the definition of 
   cofactor above.
-  The comment can be found here: https://tinyurl.com/4c55v86t
+  The comment can be found here: 
+    https://github.com/leanprover-community/mathlib/blob/cb9077f70849a93b19e01903d497029014d76e35/src/linear_algebra/matrix/adjugate.lean#L182
   The proof in that case would be 
     rw ← cofactor , apply adjugate_eq_cofactor_transpose, -/
 
@@ -44,7 +45,7 @@ begin
   rw mul_ite, rw ite_mul, rw mul_zero, rw zero_mul, },
   simp only [mul_one, finset.sum_ite_eq', finset.mem_univ, if_true, 
     neg_one_pow_mul_eq_zero_iff],
-  rw submatrix_succ_above,
+  rw submatrix_update_row_succ_above,
 end
 lemma eq_147 : (adjugate A)ᵀ = of (λ i j, adjugate A j i) := rfl
 lemma eq_148 : adjugate A = (adjugate A)ᵀᵀ := rfl

--- a/src/matrix_cookbook/3_inverses.lean
+++ b/src/matrix_cookbook/3_inverses.lean
@@ -1,5 +1,6 @@
 import linear_algebra.matrix.nonsingular_inverse
 import data.complex.basic
+import matrix_cookbook.for_mathlib.linear_algebra.matrix.adjugate
 
 /-! # Inverses -/
 
@@ -22,7 +23,29 @@ lemma eq_145 (h : is_unit A.det) : A * A⁻¹ = 1 ∧ A⁻¹ * A = 1 :=
 /-! ### Cofactors and Adjoint -/
 
 lemma eq_146 (n : ℕ) (A : matrix (fin n.succ) (fin n.succ) ℂ) (i j) :
-  adjugate A j i = (-1)^(i + j : ℕ) * det (A.submatrix i.succ_above j.succ_above) := sorry
+  adjugate A j i = (-1)^(i + j : ℕ) * det (A.submatrix i.succ_above j.succ_above) := 
+begin
+  /- The comment on line 182 of the adjugate file says that the definition of adjugate
+  uses some kind of cramer map to make some things easier. I guess the price we have to pay
+  is to show equivalence of that definiton to the cofactor definition. Eric mentions that
+  mathlib people do not prefer new definitions so we will not use the definition of 
+  cofactor above.
+  The comment can be found here: https://tinyurl.com/4c55v86t
+  The proof in that case would be 
+    rw ← cofactor , apply adjugate_eq_cofactor_transpose, -/
+
+  rw adjugate, 
+  dsimp,
+  rw cramer_transpose_apply,
+  rw det_succ_row _ i,
+  conv_lhs { apply_congr, skip, rw update_row_apply, },
+  simp only [eq_self_iff_true, if_true],
+  conv_lhs {apply_congr, skip, rw pi.single_apply j (1:ℂ) x, 
+  rw mul_ite, rw ite_mul, rw mul_zero, rw zero_mul, },
+  simp only [mul_one, finset.sum_ite_eq', finset.mem_univ, if_true, 
+    neg_one_pow_mul_eq_zero_iff],
+  rw submatrix_succ_above,
+end
 lemma eq_147 : (adjugate A)ᵀ = of (λ i j, adjugate A j i) := rfl
 lemma eq_148 : adjugate A = (adjugate A)ᵀᵀ := rfl
 
@@ -32,7 +55,27 @@ lemma eq_148 : adjugate A = (adjugate A)ᵀᵀ := rfl
 lemma eq_149 (n : ℕ) (A : matrix (fin n.succ) (fin n.succ) ℂ) :
   det A = ∑ i : fin n.succ, (-1) ^ (i : ℕ) * A i 0 * det (A.submatrix i.succ_above fin.succ) :=
 det_succ_column_zero _
-lemma eq_150 : sorry := sorry
+lemma eq_150 (n : ℕ) (A : matrix (fin n.succ) (fin n.succ) ℂ) : 
+  -- (-1) ^ (i : ℕ) * adjugate A 0 i represents cofactor
+  det A = ∑ i : fin n.succ, (-1) ^ (i : ℕ) * A i 0 * ((-1) ^ (i : ℕ) * adjugate A 0 i) := 
+begin
+  /- Use tactic was not working inside conv mode -/
+  /- Also nth_rewrite was not working inside conv mode -/
+  have even_wierd: ∀ (n: ℕ), (-1:ℂ)^(n + n) = 1, 
+  { intro n, rw even.neg_one_pow, use n, },
+  
+  conv_rhs 
+  { apply_congr, 
+    skip, 
+    rw eq_146, 
+    rw fin.coe_zero, 
+    rw add_zero, 
+    rw fin.succ_above_zero, 
+    rw ← mul_assoc ((-1:ℂ)^(x:ℕ)) _ _,
+    rw ← pow_add,
+    rw even_wierd (↑x:ℕ), rw one_mul, }, 
+  apply eq_149,
+end
 
 /-! ### Construction -/
 

--- a/src/matrix_cookbook/3_inverses.lean
+++ b/src/matrix_cookbook/3_inverses.lean
@@ -24,30 +24,7 @@ lemma eq_145 (h : is_unit A.det) : A * A⁻¹ = 1 ∧ A⁻¹ * A = 1 :=
 
 lemma eq_146 (n : ℕ) (A : matrix (fin n.succ) (fin n.succ) ℂ) (i j) :
   adjugate A j i = (-1)^(i + j : ℕ) * det (A.submatrix i.succ_above j.succ_above) := 
-begin
-  /- The comment on line 182 of the adjugate file says that the definition of adjugate
-  uses some kind of cramer map to make some things easier. I guess the price we have to pay
-  is to show equivalence of that definiton to the cofactor definition. Eric mentions that
-  mathlib people do not prefer new definitions so we will not use the definition of 
-  cofactor above.
-  The comment can be found here: 
-    https://github.com/leanprover-community/mathlib/blob/cb9077f70849a93b19e01903d497029014d76e35/src/linear_algebra/matrix/adjugate.lean#L182
-  The proof in that case would be 
-    rw ← cofactor , apply adjugate_eq_cofactor_transpose, -/
-
-  rw adjugate, 
-  dsimp,
-  rw [cramer_transpose_apply, det_succ_row _ i],
-  conv_lhs 
-  { apply_congr, skip, rw update_row_apply, },
-  simp only [eq_self_iff_true, if_true],
-  conv_lhs 
-  {apply_congr, skip, rw pi.single_apply j (1:ℂ) x, 
-    rw [mul_ite, ite_mul, mul_zero, zero_mul], },
-  simp only [mul_one, finset.sum_ite_eq', 
-    finset.mem_univ, if_true, neg_one_pow_mul_eq_zero_iff],
-  rw submatrix_update_row_succ_above,
-end
+adjugate_eq_det_submatrix A j i
 lemma eq_147 : (adjugate A)ᵀ = of (λ i j, adjugate A j i) := rfl
 lemma eq_148 : adjugate A = (adjugate A)ᵀᵀ := rfl
 
@@ -57,27 +34,9 @@ lemma eq_148 : adjugate A = (adjugate A)ᵀᵀ := rfl
 lemma eq_149 (n : ℕ) (A : matrix (fin n.succ) (fin n.succ) ℂ) :
   det A = ∑ i : fin n.succ, (-1) ^ (i : ℕ) * A i 0 * det (A.submatrix i.succ_above fin.succ) :=
 det_succ_column_zero _
-lemma eq_150 (n : ℕ) (A : matrix (fin n.succ) (fin n.succ) ℂ) : 
-  -- (-1) ^ (i : ℕ) * adjugate A 0 i represents cofactor
-  det A = ∑ i : fin n.succ, (-1) ^ (i : ℕ) * A i 0 * ((-1) ^ (i : ℕ) * adjugate A 0 i) := 
-begin
-  /- Use tactic was not working inside conv mode -/
-  /- Also nth_rewrite was not working inside conv mode -/
-  have even_wierd: ∀ (n: ℕ), (-1:ℂ)^(n + n) = 1, 
-  { intro n, rw even.neg_one_pow, use n, },
-  
-  conv_rhs 
-  { apply_congr, 
-    skip, 
-    rw eq_146, 
-    rw fin.coe_zero, 
-    rw add_zero, 
-    rw fin.succ_above_zero, 
-    rw ← mul_assoc ((-1:ℂ)^(x:ℕ)) _ _,
-    rw ← pow_add,
-    rw even_wierd (↑x:ℕ), rw one_mul, }, 
-  apply eq_149,
-end
+lemma eq_150 (n : ℕ) (A : matrix (fin n.succ) (fin n.succ) ℂ) :
+  det A = ∑ j : fin n.succ, A 0 j * adjugate A j 0 := 
+det_eq_sum_mul_adjugate_row _ _
 
 /-! ### Construction -/
 

--- a/src/matrix_cookbook/3_inverses.lean
+++ b/src/matrix_cookbook/3_inverses.lean
@@ -21,19 +21,20 @@ lemma eq_145 (h : is_unit A.det) : A * A⁻¹ = 1 ∧ A⁻¹ * A = 1 :=
 ⟨mul_nonsing_inv _ h, nonsing_inv_mul _ h⟩
 
 /-! ### Cofactors and Adjoint -/
-def cofactor {n : ℕ} (A : matrix (fin n.succ) (fin n.succ) ℂ) := 
-  matrix.of (λ i j: (fin n.succ), (-1)^(i + j : ℕ) * det (A.submatrix i.succ_above j.succ_above))
 
-lemma eq_146 {n : ℕ} (A : matrix (fin n.succ) (fin n.succ) ℂ) (i j) :
-  cofactor A i j = (-1)^(i + j : ℕ) * det (A.submatrix i.succ_above j.succ_above) := 
-by rw [cofactor, of_apply]
+-- mathlib has no need for this due to `eq_148`, but we include it for completeness
+@[reducible] def cofactor {n : ℕ} (A : matrix (fin n.succ) (fin n.succ) ℂ) :
+  matrix (fin n.succ) (fin n.succ) ℂ := 
+of (λ i j : fin n.succ, (-1)^(i + j : ℕ) * det (A.submatrix i.succ_above j.succ_above))
+
+lemma eq_146 {n : ℕ} (A : matrix (fin n.succ) (fin n.succ) ℂ) (i j : fin n.succ) :
+  cofactor A i j = (-1)^(i + j : ℕ) * det (A.submatrix i.succ_above j.succ_above) := rfl
 
 lemma eq_147 {n : ℕ} (A : matrix (fin n.succ) (fin n.succ) ℂ) : 
-  (cofactor A) = of (λ i j, cofactor A i j) := rfl -- eq_147 is a trivial matrix definiton!
+  cofactor A = of (λ i j, cofactor A i j) := rfl -- eq_147 is a trivial matrix definiton!
 
-lemma eq_148 {n : ℕ} (A : matrix (fin n.succ) (fin n.succ) ℂ) : adjugate A = (cofactor A)ᵀ := begin
-  funext r s, rw [transpose_apply, cofactor, adjugate_eq_det_submatrix], refl,
-end
+lemma eq_148 {n : ℕ} (A : matrix (fin n.succ) (fin n.succ) ℂ) : adjugate A = (cofactor A)ᵀ :=
+matrix.ext $ adjugate_eq_det_submatrix _
 
 /-! ### Determinant -/
 

--- a/src/matrix_cookbook/for_mathlib/data/matrix.lean
+++ b/src/matrix_cookbook/for_mathlib/data/matrix.lean
@@ -4,6 +4,21 @@ import data.matrix.notation
 import data.fintype.big_operators
 import tactic.norm_fin
 
+/-! # Lemmas about removing rows and columns -/
+namespace matrix
+
+@[simp] lemma submatrix_update_row_succ_above {α k l} {n : ℕ} (A : matrix (fin n.succ) k α)
+  (v : k → α) (f : l → k) (i) :
+  (A.update_row i v).submatrix i.succ_above f = A.submatrix i.succ_above f :=
+ext $ λ r s, (congr_fun (update_row_ne (fin.succ_above_ne i r) : _ = A _) (f s) : _)
+
+@[simp] lemma submatrix_update_column_succ_above {α k l} {n : ℕ} (A : matrix k (fin n.succ) α)
+  (v : k → α) (f : l → k) (i) :
+  (A.update_column i v).submatrix f i.succ_above = A.submatrix f  i.succ_above:=
+ext $ λ r s, update_column_ne (fin.succ_above_ne i s)
+
+end matrix
+
 /-! # Missing lemmas about Trace and Determinant of 4 x 4 matrices -/
 
 variables {R : Type*} [comm_ring R]

--- a/src/matrix_cookbook/for_mathlib/linear_algebra/matrix/adjugate.lean
+++ b/src/matrix_cookbook/for_mathlib/linear_algebra/matrix/adjugate.lean
@@ -17,28 +17,28 @@ import matrix_cookbook.for_mathlib.data.matrix
 open matrix
 open_locale matrix big_operators
 
-variables {R: Type*}[comm_ring R]
+variables {R : Type*} [comm_ring R]
 
-def cofactor {n : ℕ} (A : matrix (fin n.succ) (fin n.succ) R) (i j: fin n.succ)  :=
-  (-1)^(i + j : ℕ) * det (A.submatrix i.succ_above j.succ_above)
-
-/- Lemma should state
-lemma eq_146 (n : ℕ) (A : matrix (fin n.succ) (fin n.succ) ℂ) (i j) :
-  adjugate A j i = cofactor A i j := 
--/
-lemma adjugate_eq_cofactor_transpose {n : ℕ} (A : matrix (fin n.succ) (fin n.succ) R) 
-  (i j) : adjugate A j i = cofactor A i j := 
+lemma adjugate_eq_det_submatrix {n : ℕ} (A : matrix (fin n.succ) (fin n.succ) R) (i j) :
+  adjugate A i j = (-1)^(j + i : ℕ) * det (A.submatrix j.succ_above i.succ_above) := 
 begin
-  rw adjugate, dsimp,
-  rw cramer_transpose_apply,
-  rw det_succ_row _ i,
-  conv_lhs { apply_congr, skip, rw update_row_apply, },
-  simp only [eq_self_iff_true, if_true],
-  conv_lhs {apply_congr, skip, rw pi.single_apply j (1:R) x, 
-  rw mul_ite, rw ite_mul, rw mul_zero, rw zero_mul, },
-  simp only [mul_one, finset.sum_ite_eq', finset.mem_univ, if_true, 
-    neg_one_pow_mul_eq_zero_iff],
-  rw cofactor,
-  rw submatrix_update_row_succ_above,
+  simp_rw [adjugate_apply, det_succ_row _ j, update_row_self, submatrix_update_row_succ_above],
+  rw [fintype.sum_eq_single i (λ h hjk, _), pi.single_eq_same, mul_one],
+  rw [pi.single_eq_of_ne hjk, mul_zero, zero_mul],
 end
 
+lemma det_eq_sum_mul_adjugate_row {n : Type*} [decidable_eq n] [fintype n]
+  (A : matrix n n R) (i : n) :
+  det A = ∑ j : n, A i j * adjugate A j i := 
+begin
+  haveI : nonempty n := ⟨i⟩,
+  obtain ⟨n', hn'⟩ := nat.exists_eq_succ_of_ne_zero (fintype.card_ne_zero : fintype.card n ≠ 0),
+  obtain ⟨e⟩ := fintype.trunc_equiv_fin_of_card_eq hn',
+  let A' := reindex e e A,
+  suffices : det A' = ∑ j : fin n'.succ, A' (e i) j * adjugate A' j (e i),
+  { simp_rw [A', det_reindex_self, adjugate_reindex, reindex_apply, submatrix_apply, ←e.sum_comp,
+      equiv.symm_apply_apply] at this,
+    exact this },
+  rw det_succ_row A' (e i),
+  simp_rw [mul_assoc, mul_left_comm _ (A' _ _), ←adjugate_eq_det_submatrix],
+end

--- a/src/matrix_cookbook/for_mathlib/linear_algebra/matrix/adjugate.lean
+++ b/src/matrix_cookbook/for_mathlib/linear_algebra/matrix/adjugate.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2023 Mohanad Ahmed. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Mohanad Ahmed
+Authors: Mohanad Ahmed, Eric Wieser
 -/
 
 import data.matrix.basic
@@ -20,7 +20,7 @@ open_locale matrix big_operators
 variables {R : Type*} [comm_ring R]
 
 lemma adjugate_eq_det_submatrix {n : ℕ} (A : matrix (fin n.succ) (fin n.succ) R) (i j) :
-  adjugate A i j = (-1)^(j + i : ℕ) * det (A.submatrix j.succ_above i.succ_above) := 
+  adjugate A i j = (-1)^(j + i : ℕ) * det (A.submatrix j.succ_above i.succ_above) :=
 begin
   simp_rw [adjugate_apply, det_succ_row _ j, update_row_self, submatrix_update_row_succ_above],
   rw [fintype.sum_eq_single i (λ h hjk, _), pi.single_eq_same, mul_one],
@@ -29,7 +29,7 @@ end
 
 lemma det_eq_sum_mul_adjugate_row {n : Type*} [decidable_eq n] [fintype n]
   (A : matrix n n R) (i : n) :
-  det A = ∑ j : n, A i j * adjugate A j i := 
+  det A = ∑ j : n, A i j * adjugate A j i :=
 begin
   haveI : nonempty n := ⟨i⟩,
   obtain ⟨n', hn'⟩ := nat.exists_eq_succ_of_ne_zero (fintype.card_ne_zero : fintype.card n ≠ 0),
@@ -42,3 +42,8 @@ begin
   rw det_succ_row A' (e i),
   simp_rw [mul_assoc, mul_left_comm _ (A' _ _), ←adjugate_eq_det_submatrix],
 end
+
+lemma det_eq_sum_mul_adjugate_col {n : Type*} [decidable_eq n] [fintype n]
+  (A : matrix n n R) (j : n) :
+  det A = ∑ i : n, A i j * adjugate A j i :=
+by simpa only [det_transpose, ←adjugate_transpose] using det_eq_sum_mul_adjugate_row Aᵀ j

--- a/src/matrix_cookbook/for_mathlib/linear_algebra/matrix/adjugate.lean
+++ b/src/matrix_cookbook/for_mathlib/linear_algebra/matrix/adjugate.lean
@@ -15,7 +15,10 @@ import data.matrix.notation
 open matrix
 open_locale matrix big_operators
 
-lemma submatrix_update_row_succ_above {α k l} {n : ℕ} {A : matrix (fin n.succ) k α} (v : k → α) {f : l → k} {i} : 
+variables {R: Type*}[comm_ring R]
+
+lemma submatrix_update_row_succ_above {α k l} {n : ℕ} {A : matrix (fin n.succ) k α} 
+  (v : k → α) {f : l → k} {i} : 
   (A.update_row i v).submatrix i.succ_above f = A.submatrix i.succ_above f := 
 ext $ λ r s, (congr_fun (update_row_ne (fin.succ_above_ne i r) : _ = A _) (f s) : _)
 
@@ -24,14 +27,14 @@ lemma submatrix_update_column_succ_above {α k l} {n : ℕ} {A : matrix k (fin n
   (A.update_column i v).submatrix f i.succ_above = A.submatrix f  i.succ_above:= 
 ext $ λ r s, update_column_ne (fin.succ_above_ne i s)
 
-def cofactor {n : ℕ} (A : matrix (fin n.succ) (fin n.succ) ℂ) (i j: fin n.succ)  :=
+def cofactor {n : ℕ} (A : matrix (fin n.succ) (fin n.succ) R) (i j: fin n.succ)  :=
   (-1)^(i + j : ℕ) * det (A.submatrix i.succ_above j.succ_above)
 
 /- Lemma should state
 lemma eq_146 (n : ℕ) (A : matrix (fin n.succ) (fin n.succ) ℂ) (i j) :
   adjugate A j i = cofactor A i j := 
 -/
-lemma adjugate_eq_cofactor_transpose {n : ℕ} (A : matrix (fin n.succ) (fin n.succ) ℂ) 
+lemma adjugate_eq_cofactor_transpose {n : ℕ} (A : matrix (fin n.succ) (fin n.succ) R) 
   (i j) : adjugate A j i = cofactor A i j := 
 begin
   rw adjugate, dsimp,
@@ -39,11 +42,11 @@ begin
   rw det_succ_row _ i,
   conv_lhs { apply_congr, skip, rw update_row_apply, },
   simp only [eq_self_iff_true, if_true],
-  conv_lhs {apply_congr, skip, rw pi.single_apply j (1:ℂ) x, 
+  conv_lhs {apply_congr, skip, rw pi.single_apply j (1:R) x, 
   rw mul_ite, rw ite_mul, rw mul_zero, rw zero_mul, },
   simp only [mul_one, finset.sum_ite_eq', finset.mem_univ, if_true, 
     neg_one_pow_mul_eq_zero_iff],
   rw cofactor,
-  rw submatrix_succ_above,
+  rw submatrix_update_row_succ_above,
 end
 

--- a/src/matrix_cookbook/for_mathlib/linear_algebra/matrix/adjugate.lean
+++ b/src/matrix_cookbook/for_mathlib/linear_algebra/matrix/adjugate.lean
@@ -10,22 +10,14 @@ import linear_algebra.matrix.determinant
 import linear_algebra.matrix.nonsingular_inverse
 import data.matrix.notation
 
+import matrix_cookbook.for_mathlib.data.matrix
+
 /-! # Adjugate Matrix : Extra Lemmas -/
 
 open matrix
 open_locale matrix big_operators
 
 variables {R: Type*}[comm_ring R]
-
-lemma submatrix_update_row_succ_above {α k l} {n : ℕ} {A : matrix (fin n.succ) k α} 
-  (v : k → α) {f : l → k} {i} : 
-  (A.update_row i v).submatrix i.succ_above f = A.submatrix i.succ_above f := 
-ext $ λ r s, (congr_fun (update_row_ne (fin.succ_above_ne i r) : _ = A _) (f s) : _)
-
-lemma submatrix_update_column_succ_above {α k l} {n : ℕ} {A : matrix k (fin n.succ) α} (v : k → α)
-  {f : l → k} {i} : 
-  (A.update_column i v).submatrix f i.succ_above = A.submatrix f  i.succ_above:= 
-ext $ λ r s, update_column_ne (fin.succ_above_ne i s)
 
 def cofactor {n : ℕ} (A : matrix (fin n.succ) (fin n.succ) R) (i j: fin n.succ)  :=
   (-1)^(i + j : ℕ) * det (A.submatrix i.succ_above j.succ_above)

--- a/src/matrix_cookbook/for_mathlib/linear_algebra/matrix/adjugate.lean
+++ b/src/matrix_cookbook/for_mathlib/linear_algebra/matrix/adjugate.lean
@@ -1,0 +1,53 @@
+/-
+Copyright (c) 2023 Mohanad Ahmed. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mohanad Ahmed
+-/
+
+import data.matrix.basic
+import data.complex.basic
+import linear_algebra.matrix.determinant
+import linear_algebra.matrix.nonsingular_inverse
+import data.matrix.notation
+
+/-! # Adjugate Matrix : Extra Lemmas -/
+
+open matrix
+open_locale matrix big_operators
+
+lemma submatrix_succ_above  {n : ℕ} {A : matrix (fin n.succ) (fin n.succ) ℂ} {i j} : 
+  (A.update_row i (pi.single j 1)).submatrix i.succ_above j.succ_above = 
+    A.submatrix i.succ_above j.succ_above := 
+begin
+  funext r s,
+  rw submatrix_apply,
+  rw submatrix_apply,
+  rw update_row_apply,
+  rw if_eq_of_eq_false,
+  rw eq_iff_iff, split, apply fin.succ_above_ne, 
+  trivial,
+end
+
+def cofactor {n : ℕ} (A : matrix (fin n.succ) (fin n.succ) ℂ) (i j: fin n.succ)  :=
+  (-1)^(i + j : ℕ) * det (A.submatrix i.succ_above j.succ_above)
+
+/- Lemma should state
+lemma eq_146 (n : ℕ) (A : matrix (fin n.succ) (fin n.succ) ℂ) (i j) :
+  adjugate A j i = cofactor A i j := 
+-/
+lemma adjugate_eq_cofactor_transpose {n : ℕ} (A : matrix (fin n.succ) (fin n.succ) ℂ) 
+  (i j) : adjugate A j i = cofactor A i j := 
+begin
+  rw adjugate, dsimp,
+  rw cramer_transpose_apply,
+  rw det_succ_row _ i,
+  conv_lhs { apply_congr, skip, rw update_row_apply, },
+  simp only [eq_self_iff_true, if_true],
+  conv_lhs {apply_congr, skip, rw pi.single_apply j (1:ℂ) x, 
+  rw mul_ite, rw ite_mul, rw mul_zero, rw zero_mul, },
+  simp only [mul_one, finset.sum_ite_eq', finset.mem_univ, if_true, 
+    neg_one_pow_mul_eq_zero_iff],
+  rw cofactor,
+  rw submatrix_succ_above,
+end
+

--- a/src/matrix_cookbook/for_mathlib/linear_algebra/matrix/adjugate.lean
+++ b/src/matrix_cookbook/for_mathlib/linear_algebra/matrix/adjugate.lean
@@ -15,17 +15,14 @@ import data.matrix.notation
 open matrix
 open_locale matrix big_operators
 
-lemma submatrix_succ_above {α k l} {n : ℕ} {A : matrix (fin n.succ) k α} (v : k → α) {f : l → k} {i} : 
+lemma submatrix_update_row_succ_above {α k l} {n : ℕ} {A : matrix (fin n.succ) k α} (v : k → α) {f : l → k} {i} : 
   (A.update_row i v).submatrix i.succ_above f = A.submatrix i.succ_above f := 
-begin
-  funext r s,
-  rw submatrix_apply,
-  rw submatrix_apply,
-  rw update_row_apply,
-  rw if_eq_of_eq_false,
-  rw eq_iff_iff, split, apply fin.succ_above_ne, 
-  trivial,
-end
+ext $ λ r s, (congr_fun (update_row_ne (fin.succ_above_ne i r) : _ = A _) (f s) : _)
+
+lemma submatrix_update_column_succ_above {α k l} {n : ℕ} {A : matrix k (fin n.succ) α} (v : k → α)
+  {f : l → k} {i} : 
+  (A.update_column i v).submatrix f i.succ_above = A.submatrix f  i.succ_above:= 
+ext $ λ r s, update_column_ne (fin.succ_above_ne i s)
 
 def cofactor {n : ℕ} (A : matrix (fin n.succ) (fin n.succ) ℂ) (i j: fin n.succ)  :=
   (-1)^(i + j : ℕ) * det (A.submatrix i.succ_above j.succ_above)

--- a/src/matrix_cookbook/for_mathlib/linear_algebra/matrix/adjugate.lean
+++ b/src/matrix_cookbook/for_mathlib/linear_algebra/matrix/adjugate.lean
@@ -15,9 +15,8 @@ import data.matrix.notation
 open matrix
 open_locale matrix big_operators
 
-lemma submatrix_succ_above  {n : ℕ} {A : matrix (fin n.succ) (fin n.succ) ℂ} {i j} : 
-  (A.update_row i (pi.single j 1)).submatrix i.succ_above j.succ_above = 
-    A.submatrix i.succ_above j.succ_above := 
+lemma submatrix_succ_above {α k l} {n : ℕ} {A : matrix (fin n.succ) k α} (v : k → α) {f : l → k} {i} : 
+  (A.update_row i v).submatrix i.succ_above f = A.submatrix i.succ_above f := 
 begin
   funext r s,
   rw submatrix_apply,


### PR DESCRIPTION
# Equations 146 and 150

Side Lemmas:
- `submatrix_succ_above`: Lemma reduces `update_row ` in the row to be deleted by `submatrix` does not matter.
- `cofactor`: the definition of cofactor of element `i j`
- `adjugate_eq_cofactor_transpose `: equivalence between the mathlib definition (using "Cramer Maps") and the cofactor definition.

