### PR TITLE
Eq 12 and Eq 18: Determinant and Trace are Product and Sum of Eigenvalues 

### DIFF
--- a/leanpkg.toml
+++ b/leanpkg.toml
@@ -1,8 +1,8 @@
 [package]
 name = "lean-matrix-cookbook"
 version = "0.1"
-lean_version = "leanprover-community/lean:3.50.3"
+lean_version = "leanprover-community/lean:3.51.1"
 path = "src"
 
 [dependencies]
-mathlib = {git = "https://github.com/leanprover-community/mathlib", rev = "730c6d4cab72b9d84fcfb9e95e8796e9cd8f40ba"}
+mathlib = {git = "https://github.com/leanprover-community/mathlib", rev = "48dc6abe71248bd6f4bffc9703dc87bdd4e37d0b"}

--- a/src/matrix_cookbook/1_basic.lean
+++ b/src/matrix_cookbook/1_basic.lean
@@ -5,8 +5,10 @@ import topology.metric_space.basic
 import data.matrix.notation
 import ring_theory.power_series.basic
 import tactic.norm_fin
+import linear_algebra.matrix.schur_complement
 
 import matrix_cookbook.lib.trace_det_fin_four
+import matrix_cookbook.lib.eigs
 
 /-! # Basics -/
 
@@ -37,7 +39,7 @@ lemma eq_10 [star_ring R] {l : list (matrix m m R)} : l.prodᴴ = (l.map conj_tr
 section
 
 lemma eq_11 {A : matrix m m R} : trace A = ∑ i, A i i := rfl
-lemma eq_12 {A : matrix m m R} (eigvals : m → R) : trace A = ∑ i, eigvals i := sorry
+lemma eq_12 {A : matrix m m R}[is_alg_closed R] : trace A = (eigs A).sum := trace_eq_sum_eigs A
 lemma eq_13 {A : matrix m m R} : trace A = trace Aᵀ := (matrix.trace_transpose _).symm
 lemma eq_14 {A : matrix m n R} {B : matrix n m R} : trace (A ⬝ B) = trace (B ⬝ A) := matrix.trace_mul_comm _ _
 lemma eq_15 {A B : matrix m m R} : trace (A + B) = trace A + trace B := trace_add _ _
@@ -50,7 +52,7 @@ end
 /-! ### Determinant -/
 
 -- `matrix.is_hermitian.det_eq_prod_eigenvalues` is close, but needs `A` to be hermitian which is too strong
-lemma eq_18 {A : matrix m m R} (eigvals : m → R) : det A = ∏ i, eigvals i := sorry
+lemma eq_18 {A : matrix m m R}[is_alg_closed R] : det A = (eigs A).prod := det_eq_prod_eigs A
 lemma eq_19 (c : R) {A : matrix m m R} : det (c • A) = c ^ fintype.card m * det A := det_smul _ _
 lemma eq_20 {A : matrix m m R} : det (Aᵀ) = det A := det_transpose _
 lemma eq_21 {A B : matrix m m R} : det (A * B) = det A * det B := det_mul _ _
@@ -64,8 +66,8 @@ lemma eq_26 {A : matrix (fin 3) (fin 3) R} [invertible (2 : R)] :
   det (1 + A) = 1 + det A + trace A + ⅟2*trace A^2 - ⅟2*trace (A^2) :=
 begin
   apply mul_left_cancel₀ (is_unit_of_invertible (2 : R)).ne_zero,
-  simp only [det_fin_three, trace_fin_three, pow_two, matrix.mul_eq_mul, matrix.mul_apply, fin.sum_univ_succ,
-    matrix.one_apply],
+  simp only [det_fin_three, trace_fin_three, pow_two, matrix.mul_eq_mul, matrix.mul_apply, 
+    fin.sum_univ_succ, matrix.one_apply],
   dsimp,
   simp only [mul_add, mul_sub, mul_inv_of_self_assoc],
   simp_rw matrix.one_apply,

--- a/src/matrix_cookbook/lib/eigs.lean
+++ b/src/matrix_cookbook/lib/eigs.lean
@@ -1,0 +1,125 @@
+/-
+Copyright (c) 2023 Mohanad Ahmed, Eric Wieser. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mohanad Ahmed, Eric Wieser
+-/
+import linear_algebra.matrix.spectrum
+import linear_algebra.eigenspace
+import linear_algebra.charpoly.to_matrix
+import linear_algebra.matrix.charpoly.minpoly
+import linear_algebra.matrix.to_linear_equiv
+import linear_algebra.matrix.charpoly.eigs
+
+/-! # Lemmas about Eigenvalues with "correct" multiplicities -/
+
+/- TODO1: Add minpoly invariance under algebraic maps using Erics lemmas and use
+that to show that charpoly roots are minpoly roots and minpoly linmap roots -/
+
+/- TODO2: Link these eigenvalues to the "disconnected eigenvalues in 
+`is_hermitian.eigenvalues` "-/
+
+variables {n: Type*}[fintype n][decidable_eq n]
+variables {R: Type*}[field R][is_alg_closed R]
+
+open matrix polynomial
+open linear_map module.End  
+open_locale matrix big_operators
+
+noncomputable def eigs (A: matrix n n R): multiset R := 
+  polynomial.roots (matrix.charpoly A)
+
+lemma det_eq_prod_eigs (A: matrix n n R): A.det = (eigs A).prod :=
+by apply det_eq_prod_roots_charpoly
+
+lemma trace_eq_sum_eigs (A: matrix n n R) : A.trace = (eigs A).sum :=
+by apply trace_eq_sum_roots_charpoly
+
+
+lemma root_charpoly_of_has_eigenvalue (A: matrix n n R)(μ: R):
+  has_eigenvalue (matrix.to_lin' A) μ → A.charpoly.is_root μ:=
+begin
+  intro heig,
+  have va := has_eigenvalue.exists_has_eigenvector heig, 
+  have xa : (∃ (v : n → R) (H : v ≠ 0), (μ • 1 - A).mul_vec v = 0), 
+  { cases va with v hv, 
+    use v, 
+    rw [has_eigenvector, mem_eigenspace_iff,to_lin'_apply, and_comm, eq_comm] at hv,
+    rwa [sub_mul_vec, smul_mul_vec_assoc, one_mul_vec, sub_eq_zero], },
+  rw [matrix.charpoly, is_root, eval_det, mat_poly_equiv_charmatrix,
+    eval_sub, eval_C, eval_X, coe_scalar,← (matrix.exists_mul_vec_eq_zero_iff.1 xa)],
+end
+
+lemma has_eigenvalue_of_root_charpoly (A: matrix n n R)(μ: R):
+   A.charpoly.is_root μ → has_eigenvalue (matrix.to_lin' A) μ :=
+begin
+  rw [matrix.charpoly, is_root, eval_det, mat_poly_equiv_charmatrix,eval_sub], 
+  rw [eval_C, eval_X, coe_scalar], 
+  dsimp,
+
+  intro h,
+  have h := matrix.exists_mul_vec_eq_zero_iff.2 h, 
+  rcases h with ⟨v, hv_nz, hv⟩,
+  rw [sub_mul_vec, smul_mul_vec_assoc, one_mul_vec, sub_eq_zero, eq_comm] at hv,
+  rw [has_eigenvalue, submodule.ne_bot_iff], 
+  use v,
+  rw [mem_eigenspace_iff, to_lin'_apply],
+  split, assumption',
+end
+
+lemma root_charpoly_iff_has_eigenvalue (A: matrix n n R)(μ: R) :
+   A.charpoly.is_root μ ↔ has_eigenvalue (matrix.to_lin' A) μ := 
+begin
+  split,
+  apply has_eigenvalue_of_root_charpoly,
+  apply root_charpoly_of_has_eigenvalue,
+end
+
+lemma root_charpoly_iff_root_minpoly (A: matrix n n R)(μ: R) :
+  (minpoly R (matrix.to_lin' A)).is_root μ ↔ A.charpoly.is_root μ := 
+begin
+  split,
+  /- Bridge over has_eigenvalue to connect root_chapoly and root minpoly linear map-/
+  intro h, 
+  rw root_charpoly_iff_has_eigenvalue, 
+  apply has_eigenvalue_iff_is_root.2 h,
+  
+  rw root_charpoly_iff_has_eigenvalue, 
+  intro h,
+  apply has_eigenvalue_iff_is_root.1 h,
+end
+
+lemma eig_if_eigenvalue (A: matrix n n R)(μ: R) :
+  μ ∈ eigs A → has_eigenvalue (matrix.to_lin' A) μ := 
+begin
+  rw eigs, 
+  rw mem_roots',
+  intro h, 
+  cases h with hne hcp,
+  exact has_eigenvalue_of_root_charpoly _ _ hcp,
+end
+
+lemma eigenvalue_if_eig [nonempty n](A: matrix n n R)(μ: R) :
+  has_eigenvalue (matrix.to_lin' A) μ → μ ∈ eigs A  := 
+begin
+  rw eigs, rw mem_roots,
+  intro h,
+  exact root_charpoly_of_has_eigenvalue _ _ h,
+  have p_nz : matrix.charpoly A ≠ 0, 
+  { by_contra, 
+    replace h := congr_arg nat_degree h, 
+    have p_deg := matrix.charpoly_nat_degree_eq_dim A, 
+    have hn: fintype.card n ≠ 0, {exact fintype.card_ne_zero,},
+    rw [nat_degree_zero, p_deg] at h, 
+    exact hn h, }, 
+  exact p_nz,
+end
+
+lemma mem_eigs_iff_eigenvalue [nonempty n] (A: matrix n n R)(μ: R):
+  μ ∈ eigs A ↔  has_eigenvalue (matrix.to_lin' A) μ := 
+begin
+  split,
+  apply eig_if_eigenvalue,
+  apply eigenvalue_if_eig,
+end
+
+


### PR DESCRIPTION
Determinant and Trace are Product and Sum of Eigenvalues 
The eigenvalue as defined here is the same as the eigenvalue defined by `mathlib` for endomorphisms.

1. `root_charpoly_iff_has_eigenvalue` and lemmas for both directions
2. `mem_eigs_iff_eigenvalue` and lemmas for both directions

I ran the command `leanproject up' to get a new mathlib and it also changed lean version to 3.51.1 (in addition to changing mathlib).